### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 An MCP server that brings AI-guided spec-driven development workflow to any AI-powered IDEs beyonnd Kiro. Transform your development process with structured, step-by-step guidance from idea to implementation.
 
+<a href="https://glama.ai/mcp/servers/@kevinlin/spec-driven-dev-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@kevinlin/spec-driven-dev-mcp/badge" alt="Spec-driven Development Server MCP server" />
+</a>
+
 ## What is Spec-driven Development?
 
 Spec-driven development is a methodology that emphasizes creating detailed specifications before writing code. This approach helps ensure clear requirements, better design decisions, and more maintainable code. Our MCP server guides you through this process with AI assistance.


### PR DESCRIPTION
This PR adds a badge for the [Spec-driven Development MCP Server](https://glama.ai/mcp/servers/@kevinlin/spec-driven-dev-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@kevinlin/spec-driven-dev-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@kevinlin/spec-driven-dev-mcp/badge" alt="Spec-driven Development Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.